### PR TITLE
Rails 3.1 compatibility and gem loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg
 *.*.swp
 .idea
 test.log
+._*

--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,8 @@
+# *talbright/workling Fork Notes*
+
+* Fixed compatibility to work with Rails 3.1
+* Fixed code so that it will load without needing to install unwanted gems if you aren't going to use them (AWS for example)
+
 # *digitalhobbit/workling Fork Notes*
 
 *This particular Workling fork provides an SQS Client. See instructions below.*

--- a/lib/workling.rb
+++ b/lib/workling.rb
@@ -12,9 +12,9 @@ gem 'activesupport'
 require 'active_support/inflector'
 require 'active_support/core_ext/hash/keys'
 
-class Hash #:nodoc:
-  include ActiveSupport::CoreExtensions::Hash::Keys
-end
+# class Hash #:nodoc:
+#   include ActiveSupport::CoreExtensions::Hash::Keys
+# end
 
 require 'yaml'
 
@@ -36,16 +36,16 @@ module Workling
   end
 
   def self.path(*args)
-    if defined?(RAILS_ROOT)
-      File.join(RAILS_ROOT, *args)
+    if defined?(Rails.root)
+      File.join(Rails.root, *args)
     else
       File.join(Dir.pwd, *args)
     end
   end
 
   def self.env
-    @env ||= if defined?(RAILS_ENV)
-               RAILS_ENV.to_s
+    @env ||= if defined?(Rails.env)
+               Rails.env.to_s
              elsif defined?(RACK_ENV)
                RACK_ENV.to_s
              end
@@ -95,6 +95,7 @@ module Workling
   def self.select_client
     client_class = clients[Workling.config[:client]] || select_default_client
     client_class.load
+    Rails.logger.debug { "workling: using client class #{client_class}" }
     client_class
   end
 
@@ -172,7 +173,7 @@ module Workling
   mattr_writer :config_path
   def self.config_path
     return @@config_path if defined?(@@config_path) && @@config_path
-    @@config_path = File.join(RAILS_ROOT, 'config', 'workling.yml')
+    @@config_path = File.join(Rails.root, 'config', 'workling.yml')
   end
 
   #
@@ -182,7 +183,7 @@ module Workling
   mattr_writer :raise_exceptions
   def raise_exceptions
     return @@raise_exceptions if defined?(@@raise_exceptions)
-    @@raise_exceptions = (RAILS_ENV == "test" || RAILS_ENV == "development")
+    @@raise_exceptions = (Rails.env == "test" || Rails.env == "development")
   end
 
   def self.raise_exceptions?

--- a/lib/workling/base.rb
+++ b/lib/workling/base.rb
@@ -17,7 +17,7 @@ module Workling
 
     cattr_writer :logger
     def self.logger
-      @@logger ||= defined?(RAILS_DEFAULT_LOGGER) ? ::RAILS_DEFAULT_LOGGER : Logger.new($stdout)
+      @@logger ||= defined?(Rails.logger) ? Rails.logger : Logger.new($stdout)
     end
 
     def logger

--- a/lib/workling/clients/spawn_client.rb
+++ b/lib/workling/clients/spawn_client.rb
@@ -28,7 +28,7 @@ module Workling
       cattr_writer :options
       def self.options
         # use thread for development and test modes. easier to hunt down exceptions that way.
-        @@options ||= { :method => (RAILS_ENV == "test" || RAILS_ENV == "development" ? :fork : :thread) }
+        @@options ||= { :method => (Rails.env == "test" || Rails.env == "development" ? :fork : :thread) }
       end
 
       include Spawn if installed?

--- a/lib/workling/clients/sqs_client.rb
+++ b/lib/workling/clients/sqs_client.rb
@@ -1,6 +1,3 @@
-require 'json'
-require 'right_aws'
-
 #
 #  An SQS client
 #
@@ -28,6 +25,15 @@ module Workling
   module Clients
     class SqsClient < Workling::Clients::BrokerBase
 
+      def self.load
+        begin
+          require 'json'
+          require 'right_aws'
+        rescue Exception => e
+          Workling::Base.logger.info "WORKLING: couldn't find AWS client. Install: \"gem install right_aws\". "
+        end
+      end
+      
       unless defined?(AWS_MAX_QUEUE_NAME)
         AWS_MAX_QUEUE_NAME = 80
 

--- a/lib/workling/invokers/amqp_single_subscriber.rb
+++ b/lib/workling/invokers/amqp_single_subscriber.rb
@@ -1,5 +1,3 @@
-require 'eventmachine'
-
 #
 # TODO - Subscribes a single worker to a single queue 
 # 
@@ -7,6 +5,14 @@ module Workling
   module Invokers
     class AmqpSingleSubscriber < Workling::Invokers::Base
 
+      def self.load
+        begin
+          require 'eventmachine'
+        rescue Exception => e
+          Workling::Base.logger.info "WORKLING: couldn't find eventmachine. Install: \"gem install eventmachine\". "
+        end
+      end
+      
       def initialize(routing, client_class)
         super
       end

--- a/lib/workling/invokers/eventmachine_subscriber.rb
+++ b/lib/workling/invokers/eventmachine_subscriber.rb
@@ -1,4 +1,3 @@
-require 'eventmachine'
 
 #
 #  Subscribes the workers to the correct queues. 
@@ -6,6 +5,14 @@ require 'eventmachine'
 module Workling
   module Invokers
     class EventmachineSubscriber < Workling::Invokers::Base
+      
+      def self.load
+        begin
+          require 'eventmachine'
+        rescue Exception => e
+          Workling::Base.logger.info "WORKLING: couldn't find eventmachine. Install: \"gem install eventmachine\". "
+        end
+      end
       
       def initialize(routing, client_class)
         super


### PR DESCRIPTION
- Fixed incompatibility with Rails 3.1
- Fixed code so that it will load without needing to install unwanted gems if you aren't going to use them (AWS for example)

<!---
@huboard:{"order":3.0,"milestone_order":3,"custom_state":"blocked"}
-->
